### PR TITLE
_n literal operator

### DIFF
--- a/libraries/eosiolib/types.hpp
+++ b/libraries/eosiolib/types.hpp
@@ -119,7 +119,7 @@ namespace eosio {
        * @brief Conversion Operator
        * @return uint64_t - Converted result
        */
-      operator uint64_t()const { return value; }
+      constexpr operator uint64_t()const { return value; }
 
       // keep in sync with name::operator string() in eosio source code definition for name
       std::string to_string() const {
@@ -217,4 +217,13 @@ inline bool operator==(const checksum160& lhs, const checksum160& rhs) {
  */
 inline bool operator!=(const checksum160& lhs, const checksum160& rhs) {
    return memcmp(&lhs, &rhs, sizeof(lhs)) != 0;
+}
+
+/**
+ * name literal operator
+ * 
+ * @brief "foo"_n is a shortcut for name{eosio::string_to_name("foo")}
+ */
+inline constexpr eosio::name operator""_n(const char* s, std::size_t) {
+   return {eosio::string_to_name(s)};
 }


### PR DESCRIPTION
`"foo"_n` is a shortcut for `name{eosio::string_to_name("foo")}`

The `N` macro has the following issues:
* `N(foo)` confuses new users; they wonder where the identifier `foo` is defined. They're shocked when they learn `foo` isn't an identifier.
* `N` returns a `uint64_t` instead of a `name`. This hurts type safety.
