### PR TITLE
extended_symbol and extended_asset no longer inherit

### DIFF
--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -468,6 +468,49 @@ namespace eosio {
          return {a.quantity + b.quantity, a.contract};
       }
 
+      /// Addition operator.
+      friend extended_asset& operator+=( extended_asset& a, const extended_asset& b ) {
+         eosio_assert( a.contract == b.contract, "type mismatch" );
+         a.quantity += b.quantity;
+         return a;
+      }
+
+      /// Subtraction operator.
+      friend extended_asset& operator-=( extended_asset& a, const extended_asset& b ) {
+         eosio_assert( a.contract == b.contract, "type mismatch" );
+         a.quantity -= b.quantity;
+         return a;
+      }
+
+      /// Less than operator
+      friend bool operator<( const extended_asset& a, const extended_asset& b ) {
+         eosio_assert( a.contract == b.contract, "type mismatch" );
+         return a.quantity < b.quantity;
+      }
+
+
+      /// Comparison operator
+      friend bool operator==( const extended_asset& a, const extended_asset& b ) {
+         return std::tie(a.quantity, a.contract) == std::tie(b.quantity, b.contract);
+      }
+
+      /// Comparison operator
+      friend bool operator!=( const extended_asset& a, const extended_asset& b ) {
+         return std::tie(a.quantity, a.contract) != std::tie(b.quantity, b.contract);
+      }
+
+      /// Comparison operator
+      friend bool operator<=( const extended_asset& a, const extended_asset& b ) {
+         eosio_assert( a.contract == b.contract, "type mismatch" );
+         return a.quantity <= b.quantity;
+      }
+
+      /// Comparison operator
+      friend bool operator>=( const extended_asset& a, const extended_asset& b ) {
+         eosio_assert( a.contract == b.contract, "type mismatch" );
+         return a.quantity >= b.quantity;
+      }
+
       EOSLIB_SERIALIZE( extended_asset, (quantity)(contract) )
    };
 

--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -378,13 +378,18 @@ namespace eosio {
    *
    * @brief Extended asset which stores the information of the owner of the asset
    */
-   struct extended_asset : public asset {
+   struct extended_asset {
+      /**
+       * The asset
+       */
+      asset quantity;
+
       /**
        * The owner of the asset
        *
        * @brief The owner of the asset
        */
-      account_name contract;
+      name contract;
 
       /**
        * Get the extended symbol of the asset
@@ -392,7 +397,7 @@ namespace eosio {
        * @brief Get the extended symbol of the asset
        * @return extended_symbol - The extended symbol of the asset
        */
-      extended_symbol get_extended_symbol()const { return extended_symbol( symbol, contract ); }
+      extended_symbol get_extended_symbol()const { return extended_symbol{ quantity.symbol, contract }; }
 
       /**
        * Default constructor
@@ -406,13 +411,13 @@ namespace eosio {
        *
        * @brief Construct a new extended asset object
        */
-      extended_asset( int64_t v, extended_symbol s ):asset(v,s),contract(s.contract){}
+      extended_asset( int64_t v, extended_symbol s ):quantity(v,s.symbol),contract(s.contract){}
       /**
        * Construct a new extended asset given the asset and owner name
        *
        * @brief Construct a new extended asset object
        */
-      extended_asset( asset a, account_name c ):asset(a),contract(c){}
+      extended_asset( asset a, name c ):quantity(a),contract(c){}
 
       /**
        * %Print the extended asset
@@ -420,7 +425,7 @@ namespace eosio {
        * @brief %Print the extended asset
        */
       void print()const {
-         asset::print();
+         quantity.print();
          prints("@");
          printn(contract);
       }
@@ -432,8 +437,7 @@ namespace eosio {
        *  @return extended_asset - New extended asset with its amount is the negative amount of this extended asset
        */
       extended_asset operator-()const {
-         asset r = this->asset::operator-();
-         return {r, contract};
+         return {-quantity, contract};
       }
 
       /**
@@ -447,8 +451,7 @@ namespace eosio {
        */
       friend extended_asset operator - ( const extended_asset& a, const extended_asset& b ) {
          eosio_assert( a.contract == b.contract, "type mismatch" );
-         asset r = static_cast<const asset&>(a) - static_cast<const asset&>(b);
-         return {r, a.contract};
+         return {a.quantity - b.quantity, a.contract};
       }
 
       /**
@@ -462,11 +465,10 @@ namespace eosio {
        */
       friend extended_asset operator + ( const extended_asset& a, const extended_asset& b ) {
          eosio_assert( a.contract == b.contract, "type mismatch" );
-         asset r = static_cast<const asset&>(a) + static_cast<const asset&>(b);
-         return {r, a.contract};
+         return {a.quantity + b.quantity, a.contract};
       }
 
-      EOSLIB_SERIALIZE( extended_asset, (amount)(symbol)(contract) )
+      EOSLIB_SERIALIZE( extended_asset, (quantity)(contract) )
    };
 
 /// @} asset type

--- a/libraries/eosiolib/currency.hpp
+++ b/libraries/eosiolib/currency.hpp
@@ -94,7 +94,7 @@ namespace eosio {
          }
 
          static void inline_transfer( account_name from, account_name to, extended_asset amount, string memo = string(), permission_name perm = N(active) ) {
-            action act( permission_level( from, perm ), amount.contract, N(transfer), transfer{from,to,amount,memo} );
+            action act( permission_level( from, perm ), amount.contract, N(transfer), transfer{from,to,amount.quantity,memo} );
             act.send();
          }
 

--- a/libraries/eosiolib/symbol.hpp
+++ b/libraries/eosiolib/symbol.hpp
@@ -168,16 +168,19 @@ namespace eosio {
     * \struct Extended asset which stores the information of the owner of the symbol
     *
     */
-   struct extended_symbol : public symbol_type
+   struct extended_symbol
    {
+     /**
+      * The symbol
+      */
+     symbol_type symbol;
+
      /**
       * The owner of the symbol
       *
       * @brief The owner of the symbol
       */
-     account_name contract;
-
-     extended_symbol( symbol_name sym = 0, account_name acc = 0 ):symbol_type{sym},contract(acc){}
+     name contract;
 
       /**
        * %Print the extended symbol
@@ -185,7 +188,7 @@ namespace eosio {
        * @brief %Print the extended symbol
        */
       void print()const {
-         symbol_type::print();
+         symbol.print();
          prints("@");
          printn( contract );
       }
@@ -200,7 +203,7 @@ namespace eosio {
        * @return boolean - true if both provided symbols are the same
        */
       friend bool operator == ( const extended_symbol& a, const extended_symbol& b ) {
-        return std::tie( a.value, a.contract ) == std::tie( b.value, b.contract );
+        return std::tie( a.symbol, a.contract ) == std::tie( b.symbol, b.contract );
       }
 
       /**
@@ -212,14 +215,14 @@ namespace eosio {
        * @return boolean - true if both provided symbols are the same
        */
       friend bool operator != ( const extended_symbol& a, const extended_symbol& b ) {
-        return std::tie( a.value, a.contract ) != std::tie( b.value, b.contract );
+        return std::tie( a.symbol, a.contract ) != std::tie( b.symbol, b.contract );
       }
 
       friend bool operator < ( const extended_symbol& a, const extended_symbol& b ) {
-        return std::tie( a.value, a.contract ) < std::tie( b.value, b.contract );
+        return std::tie( a.symbol, a.contract ) < std::tie( b.symbol, b.contract );
       }
 
-      EOSLIB_SERIALIZE( extended_symbol, (value)(contract) )
+      EOSLIB_SERIALIZE( extended_symbol, (symbol)(contract) )
    };
 
    // }@ symbolapi


### PR DESCRIPTION
`extended_symbol` and `extended_asset` used to inherit from `symbol` and `asset`. The implicit conversions led to bugs, e.g. in comparison operators. They now use containment instead.

They also used to use `account_name` (`uint64_t`), which isn't type safe. They now use the `name` struct instead.

Partially fixes https://github.com/EOSIO/eos/issues/4525; other types aren't yet audited for problems.