### PR TITLE
fix: FREE_MEM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ if [[ `uname` == 'Darwin' ]]; then
    read -ra FREE_MEM <<< "$FREE_MEM"
    FREE_MEM=$((${FREE_MEM[2]%?}*(4096))) # free pages * page size
 else
-   FREE_MEM=`free | grep "Mem:" | awk '{print $4}'`
+   FREE_MEM=`LANG=C free | grep "Mem:" | awk '{print $4}'`
 fi
 
 CORES_AVAIL=`getconf _NPROCESSORS_ONLN`


### PR DESCRIPTION
FREE_MEM gets wrong value if LOCALE is distinct of English.

In spanish I get this error:

```bash
./build.sh: línea 70: /4000000 : error sintáctico: se esperaba un operando (el elemento de error es "/4000000 ")
./build.sh: línea 71: 4 <  ? 4 :  : error sintáctico: se esperaba un operando (el elemento de error es "? 4 :  ")
```